### PR TITLE
Enable copying relative paths for untracked files

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1,37 +1,44 @@
 local get_hovered_file = ya.sync(function()
-	return cx.active.current.hovered.name
+	return cx.active.current.hovered and cx.active.current.hovered.name or nil
 end)
+
+local function trim_newlines(str)
+	return (str or ""):gsub("[\r\n]", "")
+end
+
+local function notify(content, level, title)
+	ya.notify({
+		title = title or "",
+		content = content,
+		timeout = 3,
+		level = level or "info",
+	})
+end
 
 return {
 	entry = function()
 		local hovered_file_name = get_hovered_file()
-		local output, err =
-			Command("git"):arg({ "ls-tree", "--full-name", "--name-only", "HEAD", hovered_file_name }):output()
 
-		if output.stderr ~= "" then
-			ya.notify({
-				title = "Error",
-				content = output.stderr,
-				timeout = 3,
-				level = "error",
-			})
-		else
-			if output.stdout == "" then
-				ya.notify({
-					title = "",
-					content = "Nothing is copied. The file is probably not in git index",
-					timeout = 3,
-					level = "info",
-				})
-			else
-				ya.clipboard(output.stdout:gsub("[\r\n]", ""))
-				ya.notify({
-					title = "",
-					content = string.format("%s is copied", output.stdout),
-					timeout = 3,
-					level = "info",
-				})
-			end
+		if not hovered_file_name or hovered_file_name == "" then
+			notify("Nothing is copied. No hovered file", "warn")
+			return
 		end
+
+		-- Ask git for repo root and current prefix so untracked files still work.
+		local root_output = Command("git"):arg({ "rev-parse", "--show-toplevel" }):output()
+		if root_output.stderr ~= "" or root_output.stdout == "" then
+			notify("Nothing is copied. Not inside a git repo", "warn")
+			return
+		end
+
+		local prefix_output = Command("git"):arg({ "rev-parse", "--show-prefix" }):output()
+		if prefix_output.stderr ~= "" then
+			notify(prefix_output.stderr, "error", "Error")
+			return
+		end
+
+		local relative_path = trim_newlines(prefix_output.stdout) .. hovered_file_name
+		ya.clipboard(relative_path)
+		notify(string.format("%s is copied", relative_path))
 	end,
 }


### PR DESCRIPTION
this pr:
- Compute relative paths using git prefix + hovered filename so untracked files can be copied too.
- Add guards for missing hover and for non-git repos with clear notifications.
- Centralize notification/trim helpers for reuse.

Why
Users often want to copy a file's relative path even before it is tracked. The previous ls-tree approach only worked for tracked files and failed silently for untracked ones, so this makes the action more reliable and user-friendly.
