### PR TITLE
fix: update readme for new yazi versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ ya pkg add aresler/path-from-root
 Then, add the mapping to `yazi/keymap.toml`:
 
 ```
-[[manager.prepend_keymap]]
+[[mgr.prepend_keymap]]
 on = [ "c", "r" ]
 run = "plugin path-from-root"
 desc = "Copies path from git root"


### PR DESCRIPTION
using manager won't work for new yazi versions, tested on `Yazi 26.2.2 (13bdb164 2026-02-13)` and mgr is needed