### PR TITLE
Better error handling and git call simplification

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+    "runtime.version": "Lua 5.5",
+    "workspace.library": [
+        // You may need to change the path to your local plugin directory
+        "~/.config/yazi/plugins/types.yazi/",
+    ],
+}

--- a/main.lua
+++ b/main.lua
@@ -24,13 +24,6 @@ return {
 			return
 		end
 
-		-- Ask git for repo root and current prefix so untracked files still work.
-		local root_output = Command("git"):arg({ "rev-parse", "--show-toplevel" }):output()
-		if root_output.stderr ~= "" or root_output.stdout == "" then
-			notify("Nothing is copied. Not inside a git repo", "warn")
-			return
-		end
-
 		local prefix_output = Command("git"):arg({ "rev-parse", "--show-prefix" }):output()
 		if prefix_output.stderr ~= "" then
 			notify(prefix_output.stderr, "error", "Error")

--- a/main.lua
+++ b/main.lua
@@ -1,12 +1,17 @@
+--- @type fun(): Url|nil
 local get_hovered_file = ya.sync(function()
 	local hovered = cx.active.current.hovered
 	return hovered and hovered.url
 end)
 
+--- @param str string|nil
 local function trim_newlines(str)
 	return (str or ""):gsub("[\r\n]", "")
 end
 
+--- @param content string
+--- @param level? "info"|"warn"|"error"
+--- @param title? string
 local function notify(content, level, title)
 	ya.notify({
 		title = title or "",

--- a/main.lua
+++ b/main.lua
@@ -1,5 +1,6 @@
 local get_hovered_file = ya.sync(function()
-	return cx.active.current.hovered and cx.active.current.hovered.name or nil
+	local hovered = cx.active.current.hovered
+	return hovered and hovered.url
 end)
 
 local function trim_newlines(str)
@@ -17,21 +18,23 @@ end
 
 return {
 	entry = function()
-		local hovered_file_name = get_hovered_file()
+		local hovered_file = get_hovered_file()
 
-		if not hovered_file_name or hovered_file_name == "" then
+		if not hovered_file or hovered_file.name == "" then
 			notify("Nothing is copied. No hovered file", "warn")
 			return
 		end
 
-		local prefix, err = Command("git"):arg({ "rev-parse", "--show-prefix" }):output()
+		local cwd = hovered_file.parent
+
+		local prefix, err = Command("git"):arg({ "rev-parse", "--show-prefix" }):cwd(tostring(cwd)):output()
 		if not prefix or not prefix.status.success then
 			local error = err or prefix and prefix.stderr
 			notify(tostring(error), "error", "Error")
 			return
 		end
 
-		local relative_path = trim_newlines(prefix.stdout) .. hovered_file_name
+		local relative_path = trim_newlines(prefix.stdout) .. hovered_file.name
 		ya.clipboard(relative_path)
 		notify(string.format("%s is copied", relative_path))
 	end,

--- a/main.lua
+++ b/main.lua
@@ -24,13 +24,14 @@ return {
 			return
 		end
 
-		local prefix_output = Command("git"):arg({ "rev-parse", "--show-prefix" }):output()
-		if prefix_output.stderr ~= "" then
-			notify(prefix_output.stderr, "error", "Error")
+		local prefix, err = Command("git"):arg({ "rev-parse", "--show-prefix" }):output()
+		if not prefix or not prefix.status.success then
+			local error = err or prefix and prefix.stderr
+			notify(tostring(error), "error", "Error")
 			return
 		end
 
-		local relative_path = trim_newlines(prefix_output.stdout) .. hovered_file_name
+		local relative_path = trim_newlines(prefix.stdout) .. hovered_file_name
 		ya.clipboard(relative_path)
 		notify(string.format("%s is copied", relative_path))
 	end,


### PR DESCRIPTION
`git rev-parse --show-toplevel` is not needed, `git rev-parse --show-prefix` should be enough to handle "not in git repo" errors.

`Command:output()` returns `Error` tables, so it should be handled as well.

Not sure about cwd, but I think it should be set, because execution is async and you don't know with what CWD `Command` is executed.